### PR TITLE
Add option to validate file encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	},
 	"require":{
 		"php": "> 5.3.0",
-		"Psr/Log": "~1.0",
+		"psr/log": "~1.0",
 		"symfony/expression-language": "~2.4"
 	},
 	"suggest": {

--- a/lib/Networkteam/Import/DataProvider/CsvDataProvider.php
+++ b/lib/Networkteam/Import/DataProvider/CsvDataProvider.php
@@ -270,7 +270,7 @@ class CsvDataProvider implements DataProviderInterface
     protected function validateFileEncoding(): void
     {
         try {
-            $content = stream_get_contents($this->getFileHandle(), 1048576);
+            $content = stream_get_contents($this->csvFileHandle, 1048576);
             if (!mb_check_encoding($content, $this->getFileEncoding())) {
                 throw new \Exception(sprintf('File content does not follow %s encoding.', $this->getFileEncoding()), 1578925169);
             }

--- a/lib/Networkteam/Import/DataProvider/CsvDataProvider.php
+++ b/lib/Networkteam/Import/DataProvider/CsvDataProvider.php
@@ -270,7 +270,7 @@ class CsvDataProvider implements DataProviderInterface
     protected function validateFileEncoding(): void
     {
         try {
-            $content = stream_get_contents($this->getFileHandle());
+            $content = stream_get_contents($this->getFileHandle(), 1048576);
             if (!mb_check_encoding($content, $this->getFileEncoding())) {
                 throw new \Exception(sprintf('File content does not follow %s encoding.', $this->getFileEncoding()), 1578925169);
             }


### PR DESCRIPTION
Two new options:
* `csv.fileEncoding`
* `csv.fileEncodingValidationEnabled`

If `csv.fileEncodingValidationEnabled` is enabled the content is checked with `mb_check_encoding()` before file is opend.