### PR TITLE
raise php version and adjust phpoffice constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "psr-4": { "Networkteam\\Import\\Tests\\": "tests/" }
     },
     "require":{
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "psr/log": "~1.0",
         "symfony/expression-language": ">=2.4|~3.0|~4.0|~5.0"
     },
@@ -25,6 +25,6 @@
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "~8.5.2",
         "doctrine/orm": ">=2.4.0",
-        "phpoffice/phpspreadsheet": "^1.2.1"
+        "phpoffice/phpspreadsheet": "^1.22.0"
     }
 }


### PR DESCRIPTION
This allows us to use the importer package with projects that depend on php 8.